### PR TITLE
correct pub for deprecated functions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -77,7 +77,7 @@ pub fn build(b: *std.Build) !void {
     }
 }
 
-fn linkFreetype(
+pub fn linkFreetype(
     b: *std.Build,
     step: *std.Build.Step.Compile,
 ) void {
@@ -86,7 +86,7 @@ fn linkFreetype(
     @panic("linkFreetype is deprecated / no longer needed, remove the call to it.");
 }
 
-fn linkHarfbuzz(
+pub fn linkHarfbuzz(
     b: *std.Build,
     step: *std.Build.Step.Compile,
 ) void {


### PR DESCRIPTION
Compiler throws error saying linkFreetype is not public. Same for linkHarfbuzz.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.